### PR TITLE
Fix crate respawn logic on player death

### DIFF
--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -42,13 +42,12 @@ public class MyGdxGame extends ApplicationAdapter {
     private int deathCount;
 
 
-
     @Override
     public void create() {
         rocks = new Array<>();
         // Create all rocks to be used
         for (int i = 0; i < ROCK_COUNT; i++) {
-            rocks.add(new Rock(i * ((rand.nextInt(FLUCTUATION)) + MINIMUM_GAP) + WIDTH));
+            rocks.add(new Rock((i+1) * (rand.nextInt(FLUCTUATION) + MINIMUM_GAP) + WIDTH));
         }
         batch = new SpriteBatch();
         steveImage = new Texture("badlogic.jpg");
@@ -64,7 +63,7 @@ public class MyGdxGame extends ApplicationAdapter {
         steve.x = xStartPos;
         steve.y = yStartPos;
         steve.width = 150;
-        steve.height = 220;
+        steve.height = 180;
     }
 
     @Override
@@ -101,12 +100,11 @@ public class MyGdxGame extends ApplicationAdapter {
                 deathSound = Gdx.audio.newMusic(Gdx.files.internal("death.mp3"));
                 deathSound.play();
                 deathCount++;
-
                 sourceX = 0;
-                rocks.get(i).reposition(rocks.get(prevRockIndex).getPosRock().x + rand.nextInt(FLUCTUATION) + MINIMUM_GAP + rand.nextInt(deathCount*1000));
-
-
-                // TODO: Add game restart on death
+                for (int j = 0; j < rocks.size; j++) {
+                    rocks.get(j).reposition((j+1) * (rand.nextInt(FLUCTUATION) + MINIMUM_GAP) + WIDTH);
+                }
+                break;
             }
             // If a rock is to the left of the visible window, move it to the right of the window
             if (rocks.get(i).getPosRock().x < -WIDTH) {

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -101,6 +101,7 @@ public class MyGdxGame extends ApplicationAdapter {
                 deathSound.play();
                 deathCount++;
                 sourceX = 0;
+                // Randomly arrange all crates to the right of the screen
                 for (int j = 0; j < rocks.size; j++) {
                     rocks.get(j).reposition((j+1) * (rand.nextInt(FLUCTUATION) + MINIMUM_GAP) + WIDTH);
                 }

--- a/core/src/com/mygdx/game/Rock.java
+++ b/core/src/com/mygdx/game/Rock.java
@@ -14,8 +14,8 @@ public class Rock {
     public Rectangle bounds;
 
     // Obstacle placement
-    public static final int FLUCTUATION = 500;
-    public static final int MINIMUM_GAP = 500; // Min gap between two obstacles
+    public static final int FLUCTUATION = 300;
+    public static final int MINIMUM_GAP = 600; // Min gap between two obstacles
 
     // Constructor
     public Rock(float x) {


### PR DESCRIPTION
Crates' spawn point is no longer scaled by `deathCount`, as this results in very large gaps between crates once the player has died a couple of times. 